### PR TITLE
Fix Game.MapCleanUp function for maps that have too many entities

### DIFF
--- a/gamemodes/scplc/gamemode/modules/sv_round.lua
+++ b/gamemodes/scplc/gamemode/modules/sv_round.lua
@@ -172,7 +172,7 @@ function RestartRound()
 	ResetRoundStats()
 	print( string.format( "Round data reset - %i ms!", util.TimerCycle() ) )
 
-	game.CleanUpMap()
+	game.CleanUpMap( false, {}, function() end )
 	print( string.format( "Map cleaned - %i ms!", util.TimerCycle() ) )
 
 	hook.Run( "SLCRoundCleanup" )


### PR DESCRIPTION
This fix fixes a problem that has appeared since version GMod 2024.01.04 it is that if the function game.MapCleanUp() is called (without any additional arguments) on a map that has too many entities causing it to crash on both client and server (not tested on a dedicated server).